### PR TITLE
Translated services + multiple fixes

### DIFF
--- a/javinukai-front/public/locales/en/translation.json
+++ b/javinukai-front/public/locales/en/translation.json
@@ -213,5 +213,12 @@
     "blockAccount": "Block account",
     "unblockAccount": "Unblock account",
     "deleteAccountButton": "Delete account"
+  },
+
+  "roles": {
+    "ADMIN": "Admin",
+    "USER": "User",
+    "JURY": "Jury",
+    "MODERATOR": "Moderator"
   }
 }

--- a/javinukai-front/public/locales/lt/translation.json
+++ b/javinukai-front/public/locales/lt/translation.json
@@ -66,8 +66,8 @@
   "PaginationSettings": {
     "previousPage": "Ankstesnis",
     "nextPage": "Sekantis",
-    "usersTitle": "Vartotojų per puslapį",
-    "users": "vartotojai",
+    "usersTitle": "Vartotojai per puslapį",
+    "users": "vartotojų",
     "fieldTitle": "Rūšiuoti pagal lauką",
     "fieldName": "Vardas",
     "fieldSurname": "Pavardė",
@@ -213,5 +213,12 @@
       "blockAccount": "Blokuoti",
       "unblockAccount": "Atblokuoti",
       "deleteAccountButton": "Ištrinti"
-    }
+    },
+
+      "roles": {
+        "ADMIN": "Administratorius",
+        "USER": "Vartotojas",
+        "JURY": "Žiuri",
+        "MODERATOR": "Moderatorius"
+      }
 }

--- a/javinukai-front/src/Components/ImageUpload.jsx
+++ b/javinukai-front/src/Components/ImageUpload.jsx
@@ -35,7 +35,7 @@ function ImageUpload() {
       reset();
       setUploadedCollection(createdCollection);
     },
-    onError: (err) => toast.error(err.message),
+    onError: () => toast.error(t('services.uploadImagesError')),
   });
 
   const onDrop = useCallback((acceptedFiles) => {

--- a/javinukai-front/src/Components/LanguageSwitcher.jsx
+++ b/javinukai-front/src/Components/LanguageSwitcher.jsx
@@ -10,13 +10,19 @@ const lngs = {
 export default function LanguageSwitcher() {
   const currentLanguage = i18next.language;
 
+  const handleChangeLanguage = (lng) => {
+    i18next.changeLanguage(lng).then(() => {
+      window.location.reload();
+    });
+  };
+  
   return (
     <div className="flex">
       {Object.keys(lngs).map((lng) => (
         <button
           type="submit"
           key={lng}
-          onClick={() => i18next.changeLanguage(lng)}
+          onClick={() => handleChangeLanguage(lng)}
           disabled={currentLanguage === lng}
           className={`flex items-center mx-1.5 border-blue-500 ${currentLanguage === lng ? 'border-2' : 'border-0' }`}
         >

--- a/javinukai-front/src/Components/Layout.jsx
+++ b/javinukai-front/src/Components/Layout.jsx
@@ -24,7 +24,7 @@ export default function Layout() {
       removeUser();
       navigate("/");
     },
-    onError: (err) => toast.error(err.message),
+    onError: () => toast.error(t('services.logoutUserError')),
   });
 
   return (

--- a/javinukai-front/src/Components/user-management/DangerZone.jsx
+++ b/javinukai-front/src/Components/user-management/DangerZone.jsx
@@ -46,7 +46,7 @@ export function DangerZone({ userData }) {
   const deleteUserMutation = useMutation({
     mutationFn: (data) => deleteUser(data),
     onSuccess: () => {
-      toast.success(t('DangerZone.deletedSuccess', { username: userData.uuid }));
+      toast.success(t('DangerZone.deletedSuccess', { username: userData.email }));
       queryClient.invalidateQueries(["users"]);
       navigate("/manage-users");
     },

--- a/javinukai-front/src/Components/user-management/UserListItem.jsx
+++ b/javinukai-front/src/Components/user-management/UserListItem.jsx
@@ -9,7 +9,7 @@ export function UserListItem({ userInfo }) {
       to={userInfo.uuid}
       className="flex py-4 shadow bg-white xl:px-3 border-white border-4 transition ease-in-out hover:border-teal-400 hover:border-4 hover:cursor-pointer my-2 rounded-md"
     >
-      <div className="xl:grid xl:grid-cols-9 px-3 xl:px-0 w-full flex justify-between">
+      <div className="xl:grid xl:grid-cols-10 px-3 xl:px-0 w-full flex justify-between">
         <div>
           <span className="">{userInfo.name}</span>{" "}
           <span className="xl:hidden inline">{userInfo.surname}</span>
@@ -19,7 +19,7 @@ export function UserListItem({ userInfo }) {
         <p className="xl:block hidden break-all text-wrap col-span-3">
           {userInfo.email}
         </p>
-        <p className="xl:flex items-center justify-left">{userInfo.role}</p>
+        <p className="xl:flex items-center justify-left col-span-2" >{t(`roles.${userInfo.role}`) || userInfo.role}</p>
         <p className="hidden xl:flex items-center justify-left">
           {userInfo.maxTotal}/{userInfo.maxSinglePhotos}/
           {userInfo.maxCollections}

--- a/javinukai-front/src/pages/ForgotPassPage.jsx
+++ b/javinukai-front/src/pages/ForgotPassPage.jsx
@@ -17,7 +17,7 @@ function ForgotPassPage() {
   const { mutate } = useMutation({
     mutationFn: (data) => forgotPassword(data.email),
     onSuccess: () => toast.success(t('ForgotPassPage.resetSuccess')),
-    onError: (err) => toast.error(err.message),
+    onError: () => toast.error(t('services.forgotPasswordError')),
   });
 
   function onSubmit(formData) {

--- a/javinukai-front/src/pages/LoginPage.jsx
+++ b/javinukai-front/src/pages/LoginPage.jsx
@@ -26,7 +26,7 @@ function LoginPage() {
       setUser(loggedInUser);
       navigate("/");
     },
-    onError: (err) => toast.error(err.message),
+    onError: () => toast.error(t('services.loginUserError')),
   });
 
   const handleLoginSubmit = async (formData) => {

--- a/javinukai-front/src/pages/RegisterPage.jsx
+++ b/javinukai-front/src/pages/RegisterPage.jsx
@@ -36,7 +36,7 @@ function RegisterPage() {
   });
 
   function onSubmit(formData) {
-    mutate(formData);
+    mutate({registrationInfo: {formData}, t});
   }
 
   function onAffiliationChange(newAffiliation) {
@@ -92,7 +92,7 @@ function RegisterPage() {
                 },
                 maxLength: {
                   value: 20,
-                  message: t("RegisterPage.surnnameLength"),
+                  message: t("RegisterPage.surnameLength"),
                 },
               })}
             />

--- a/javinukai-front/src/pages/ResetPassPage.jsx
+++ b/javinukai-front/src/pages/ResetPassPage.jsx
@@ -41,7 +41,7 @@ function ResetPassPage() {
       );
       return;
     }
-    mutate({ token, newPassword: formData.password });
+    mutate({data:{ token, newPassword: formData.password }, t});
   }
 
   return (

--- a/javinukai-front/src/pages/UserDetailsPage.jsx
+++ b/javinukai-front/src/pages/UserDetailsPage.jsx
@@ -89,9 +89,10 @@ function UserDetailsPage() {
                   fieldName={t('UserDetailsPage.accountIsLocked')}
                   fieldValue={data?.isNonLocked ? t('UserDetailsPage.isFalse') : t('UserDetailsPage.isTrue')}
                 />
-                <UserDetailsField 
+                <UserDetailsField
                 fieldName={t('UserDetailsPage.accountRole')}
-                fieldValue={data?.role} />
+                fieldValue={t(`roles.${data?.role}`) || data?.role}
+                                />
                 <UserDetailsField
                   fieldName={t('UserDetailsPage.accountMaxPhotosContest')}
                   fieldValue={data?.maxTotal}

--- a/javinukai-front/src/pages/UserManagementPage.jsx
+++ b/javinukai-front/src/pages/UserManagementPage.jsx
@@ -46,13 +46,14 @@ export default function UserManagementPage() {
           setPagination={setPaginationSettings}
           availablePageNumber={data?.totalPages}
         />
-        <div className="hidden xl:grid xl:grid-cols-9 px-3 py-5 font-bold text-lg text-slate-700 bg-white mt-2 rounded-md shadow">
+        <div className="hidden xl:grid xl:grid-cols-10 px-3 py-5 font-bold text-lg text-slate-700 bg-white mt-2 rounded-md shadow">
           <p>{t("PaginationSettings.fieldName")}</p>
           <p>{t("PaginationSettings.fieldSurname")}</p>
           <p className="text col-span-3">
             {t("PaginationSettings.fieldEmail")}
           </p>
-          <p>{t("PaginationSettings.fieldRole")}</p>
+          <p className="text col-span-2">
+            {t("PaginationSettings.fieldRole")}</p>
           <p>{t("PaginationSettings.fieldLimits")}</p>
           <p className="text-center break-all">
             {t("PaginationSettings.fieldIsEnabled")}

--- a/javinukai-front/src/services/auth/forgotPassword.js
+++ b/javinukai-front/src/services/auth/forgotPassword.js
@@ -14,7 +14,7 @@ async function forgotPassword(email) {
     }
   );
   if (res.status === 429) {
-    throw new Error("Please check your email for the password reset link");
+    throw new Error();
   }
 }
 

--- a/javinukai-front/src/services/auth/loginUser.js
+++ b/javinukai-front/src/services/auth/loginUser.js
@@ -10,7 +10,7 @@ export default async function (loginInfo) {
     },
     body: JSON.stringify(loginInfo),
   });
-  if (!res.ok) throw new Error("Incorrect credentials");
+  if (!res.ok) throw new Error();
   const data = await res.json();
   return data;
 }

--- a/javinukai-front/src/services/auth/logoutUser.js
+++ b/javinukai-front/src/services/auth/logoutUser.js
@@ -11,5 +11,5 @@ export default async function () {
       },
     }
   );
-  if (!res.ok) throw new Error("Error occured while logging out");
+  if (!res.ok) throw new Error();
 }

--- a/javinukai-front/src/services/auth/registerUser.js
+++ b/javinukai-front/src/services/auth/registerUser.js
@@ -1,4 +1,5 @@
-export default async function (registrationInfo) {
+export default async function ({registrationInfo, t}) {
+  console.log(registrationInfo, t)
   const res = await fetch(
     `${import.meta.env.VITE_BACKEND}/api/v1/auth/register`,
     {
@@ -17,9 +18,9 @@ export default async function (registrationInfo) {
     const err = await res.json();
     switch (err.title) {
       case "USER_ALREADY_EXISTS_ERROR":
-        throw new Error("An user with this email already exists");
+        throw new Error(t('services.registerUserExistsError'));
       default:
-        throw new Error("Registration failed. Please try again later");
+        throw new Error(t('services.registerUserError'));
     }
   }
 }

--- a/javinukai-front/src/services/auth/resetPassword.js
+++ b/javinukai-front/src/services/auth/resetPassword.js
@@ -1,4 +1,5 @@
-async function resetPassword(data) {
+async function resetPassword({data, t}) {
+  console.log(data, t)
   const res = await fetch(
     `${import.meta.env.VITE_BACKEND}/api/v1/auth/reset-password`,
     {
@@ -20,12 +21,12 @@ async function resetPassword(data) {
     const err = await res.json();
     switch (err.title) {
       case "INVALID_TOKEN_ERROR":
-        throw new Error("Password reset link is invalid or expired");
+        throw new Error(t('services.resetPasswordResetLinkInvalid'));
       case "PASSWORD_RESET_ERROR":
-        throw new Error("New password can not be old password");
+        throw new Error(t('services.resetPasswordOldPasswordError'));
       default:
         throw new Error(
-          "An error has occured while trying to reset your password"
+          t('services.resetPasswordError')
         );
     }
   }

--- a/javinukai-front/src/services/uploadImages.js
+++ b/javinukai-front/src/services/uploadImages.js
@@ -1,7 +1,4 @@
-import { useTranslation } from "react-i18next";
-
 export default async function (formData) {
-  const { t } = useTranslation();
   const res = await fetch(`${import.meta.env.VITE_BACKEND}/api/v1/images`, {
     method: "POST",
     mode: "cors",
@@ -10,7 +7,7 @@ export default async function (formData) {
     body: formData,
   });
   if (!res.ok) {
-    throw new Error(t('services.uploadImagesError'));
+    throw new Error();
   }
   return await res.json();
 }


### PR DESCRIPTION
Added page reload, which updates the language of the page on language change.
Fixed an issue where roles coming from the backend would not be translated. (USER, MODERATOR, ADMIN, JURY)
Fixed an issue where translated roles would overlap with nearby components.
Fixed some incorrect translations.
Changed functionality: when deleting a user, his ID would be displayed; now his email is displayed. ("User {{email}} deleted successfully")
Translated services (registerUser provides an 400 error)
