### PR TITLE
Finished PersonalInformation page, fixed ParticipationRequest pages

### DIFF
--- a/javinukai-front/public/locales/en/translation.json
+++ b/javinukai-front/public/locales/en/translation.json
@@ -353,7 +353,8 @@
     "isFreelanceTrue": "Yes",
     "isFreelanceFalse": "No",
     "changeSuccess": "Personal information changed successfully",
-    "changeError": "An error occurred while saving personal information"
+    "changeError": "An error occurred while saving personal information",
+    "emailLogoutMessage": "Changing your email requires re-logging in with the new email"
   },
   
   "ParticipationRequest": {
@@ -370,7 +371,9 @@
     "requestDateOption": "Request date",
     "contestNameOption": "Contest name",
     "contestsLimitObject": "Requests",
-    "requestStatusOption": "Request status"
+    "requestStatusOption": "Request status",
+    "fieldAcceptSuccess": "Participation has been accepted",
+    "fieldDeclinedSuccess": "Participation has been declined"
   },
 
   "ParticipationStatus": {

--- a/javinukai-front/public/locales/lt/translation.json
+++ b/javinukai-front/public/locales/lt/translation.json
@@ -354,7 +354,8 @@
     "isFreelanceTrue": "Taip",
     "isFreelanceFalse": "Ne",
     "changeSuccess": "Asmeninė informacija sėkmingai pakeista",
-    "changeError": "Keičiant asmeninę informaciją įvyko klaida"
+    "changeError": "Keičiant asmeninę informaciją įvyko klaida",
+    "emailLogoutMessage": "Pakeitus el. pašto adresą, reikia iš naujo prisijungti naudojant naują el. pašto adresą"
   },
 
   "ParticipationRequest": {
@@ -366,12 +367,14 @@
     "fieldContestName": "Konkursas",
     "fieldContestStart": "Pradžia",
     "fieldContestEnd": "Pabaiga",
-    "fieldAccept": "Priimti",
+    "fieldAccept": "Patvirtinti",
     "fieldDecline": "Atmesti",
     "requestDateOption": "Užklausos data",
     "contestNameOption": "Konkurso pavadinimas",
     "contestsLimitObject": "Užklausos",
-    "requestStatusOption": "Užklausos būsena"
+    "requestStatusOption": "Užklausos būsena",
+    "fieldAcceptSuccess": "Užklausa patvirtinta",
+    "fieldDeclinedSuccess": "Užklausa atmesta"
   },
 
   "ParticipationStatus": {

--- a/javinukai-front/src/Components/participation-request-components/ParticipationRequest.jsx
+++ b/javinukai-front/src/Components/participation-request-components/ParticipationRequest.jsx
@@ -1,8 +1,9 @@
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
-import formatTimestap from "../../utils/formatTimestap.js";
+import toast from "react-hot-toast";
 
 const ParticipationRequest = ({ request, onButtonClick }) => {
+  
   const {
     requestId = request.requestId,
     // createdAt = request.createdAt,
@@ -10,10 +11,7 @@ const ParticipationRequest = ({ request, onButtonClick }) => {
     participantSurname = request.user.surname,
     participantEmail = request.user.email,
     participantBirthYear = request.user.birthYear,
-    participantPhoneNumber = request.user.phoneNumber,
     contestName = request.contest.name,
-    contestStartDate = request.contest.startDate,
-    contestEndDate = request.contest.endDate,
     requestStatus = request.requestStatus,
   } = request;
 
@@ -23,67 +21,59 @@ const ParticipationRequest = ({ request, onButtonClick }) => {
     <>
       <div className="xl:w-3/4 w-full px-2"></div>
       <Link
-        //   to={""}
         className="flex py-4 shadow bg-white xl:px-3 border-white border-4 transition ease-in-out hover:border-teal-400 hover:border-4 hover:cursor-pointer my-2 rounded-md"
       >
-        <div className="xl:grid xl:grid-cols-10 px-3 xl:px-0 w-full flex justify-between">
-          <div>
-            {/* <p className="xl:block hidden">{formatTimestap(createdAt)}</p> */}
-            <span className="">{participantName}</span>{" "}
-            <span className="xl:hidden inline">{participantSurname}</span>
-            <p className="xl:hidden block break-all">{participantEmail}</p>
-          </div>
-          <p className="xl:block hidden">{participantSurname}</p>
-          <p className="xl:block hidden break-all text-wrap ">
-            {participantEmail}
-          </p>
-          <p className="xl:block hidden">{participantBirthYear}</p>
-          <p className="xl:block hidden">{participantPhoneNumber}</p>
-          <p className="xl:block hidden">{contestName}</p>
-          <span className="xl:hidden inline">
-            <p>{t("ParticipationRequest.fieldContestName")}</p>
-            {contestName}
-          </span>
-          <p className="xl:block hidden">{formatTimestap(contestStartDate)}</p>
-          <p className="xl:block hidden">{formatTimestap(contestEndDate)}</p>
-          <div>
-            <button
-              type="button"
-              disabled={requestStatus === "ACCEPTED" ? true : false}
-              onClick={() => onButtonClick(requestId, "ACCEPTED")}
-              className={`${
-                requestStatus === "ACCEPTED"
-                  ? "bg-green-500 cursor-not-allowed"
-                  : "bg-gray-300 hover:bg-green-300"
-              } text-white py-2 px-4 rounded-md transition ease-in-out`}
-            >
-              {t("ParticipationRequest.fieldAccept")}
-            </button>
-          </div>
-
-          <div>
-            <button
-              type="button"
-              disabled={
-                requestStatus === "ACCEPTED" || requestStatus === "DECLINED"
-                  ? true
-                  : false
-              }
-              onClick={() => onButtonClick(requestId, "DECLINED")}
-              className={`${
-                requestStatus === "PENDING"
-                  ? "bg-gray-300 hover:bg-red-300"
-                  : `${
-                      requestStatus === "ACCEPTED"
-                        ? "bg-gray-300 cursor-not-allowed"
-                        : "bg-red-500 cursor-not-allowed"
-                    }`
-              } text-white py-2 px-4 rounded-md transition ease-in-out`}
-            >
-              {t("ParticipationRequest.fieldDecline")}
-            </button>
-          </div>
-        </div>
+        <div className="xl:grid xl:grid-cols-10  xl:px-0 w-full flex justify-between">
+  <p className="hidden xl:block text">{participantName}</p>{" "}
+  <p className="hidden xl:block text">{participantSurname}</p>
+  <p className="text col-span-3">{participantEmail}</p>
+  <p className="hidden xl:block text">{participantBirthYear}</p>
+  <p className="text col-span-2">{contestName}</p>
+  <p className="text-center">
+    <button
+    type="button"
+    disabled={requestStatus === "ACCEPTED" ? true : false}
+    onClick={() => {
+      onButtonClick(requestId, "ACCEPTED");
+      toast.success(t("ParticipationRequest.fieldAcceptSuccess"));
+    }}
+    className={`${
+      requestStatus === "ACCEPTED"
+        ? "bg-green-500 cursor-not-allowed"
+        : "bg-gray-300 hover:bg-green-300"
+    } text-white py-2 px-3 rounded-md text-center transition ease-in-out`}
+  >
+    {t("ParticipationRequest.fieldAccept")}
+  </button>
+  </p>
+  
+  <p className="text-center">
+    <button
+    type="button"
+    disabled={
+      requestStatus === "ACCEPTED" || requestStatus === "DECLINED"
+        ? true
+        : false
+    }
+    onClick={() => {onButtonClick(requestId, "DECLINED");
+    toast.success(t("ParticipationRequest.fieldDeclinedSuccess"));
+    }}
+    
+    className={`${
+      requestStatus === "PENDING"
+        ? "bg-gray-300 hover:bg-red-300"
+        : `${
+            requestStatus === "ACCEPTED"
+              ? "bg-gray-300 cursor-not-allowed"
+              : "bg-red-500 cursor-not-allowed"
+          }`
+    } text-white py-2 px-3 rounded-md text-center transition ease-in-out`}
+  >
+    {t("ParticipationRequest.fieldDecline")}
+  </button>
+  </p>
+  
+</div>
       </Link>
     </>
   );

--- a/javinukai-front/src/Components/participation-request-components/ParticipationRequests.jsx
+++ b/javinukai-front/src/Components/participation-request-components/ParticipationRequests.jsx
@@ -109,30 +109,14 @@ const ParticipationRequests = () => {
           lastPage={lastPage}
         />
 
-        <div className="hidden xl:grid xl:grid-cols-10 px-3 py-5 font-bold text-lg text-slate-700 bg-white mt-2 rounded-md shadow">
-          {/* <p>{t("ParticipationRequest.fieldRequestDate")}</p> */}
-          <p>{t("ParticipationRequest.fieldName")}</p>
-          <p>{t("ParticipationRequest.fieldSurname")}</p>
-          <p className="text ">{t("ParticipationRequest.fieldEmail")}</p>
-          <p className="text brek-all">
-            {t("ParticipationRequest.fieldBirthYear")}
-          </p>
-          <p>{t("ParticipationRequest.fieldPhoneNumber")}</p>
-          <p className="text-center break-all">
-            {t("ParticipationRequest.fieldContestName")}
-          </p>
-          <p className="text-center break-all">
-            {t("ParticipationRequest.fieldContestStart")}
-          </p>
-          <p className="text-center break-all">
-            {t("ParticipationRequest.fieldContestEnd")}
-          </p>
-          <p className="text-center break-all">
-            {t("ParticipationRequest.fieldAccept")}
-          </p>
-          <p className="text-center break-all">
-            {t("ParticipationRequest.fieldDecline")}
-          </p>
+<div className="hidden xl:grid xl:grid-cols-10 px-3 py-5 font-bold text-lg text-slate-700 bg-white mt-2 rounded-md shadow">
+          <p className="text">{t("ParticipationRequest.fieldName")}</p>
+          <p className="text">{t("ParticipationRequest.fieldSurname")}</p>
+          <p className="text col-span-3">{t("ParticipationRequest.fieldEmail")}</p>
+          <p className="text">{t("ParticipationRequest.fieldBirthYear")}</p>
+          <p className="text col-span-2">{t("ParticipationRequest.fieldContestName")}</p>
+          <p className="text-center ">{t("ParticipationRequest.fieldAccept")}</p>
+          <p className="text-center ">{t("ParticipationRequest.fieldDecline")}</p>
         </div>
         {requestsArray.map((request) => {
           return (


### PR DESCRIPTION
PersonalInformation page:
- Added change email functionality. Whenever person tries to edit email, he gets a pop-up message (Changing your email requires re-logging in with the new email).

ParticipationRequest components:
- Fixed few translations.
- Fixed the grid so the columns align.
- Removed Phone number, contest start, contest end fields.
- Added a toast for successful approval or decline of a person