### PR TITLE
Made CreateContest title reusable, added missing translations.

### DIFF
--- a/javinukai-front/public/locales/en/translation.json
+++ b/javinukai-front/public/locales/en/translation.json
@@ -271,7 +271,8 @@
     "participationSuccess": "Participations request sent successfully",
     "participationError": "An error has occured while sending a participation",
     "userEntries": "Your entries",
-    "entries": "Total entries"
+    "entries": "Total entries",
+    "contestEditTitle": "Edit contest"
   },
 
   "CategoryItem": {
@@ -517,5 +518,17 @@
     "showAll": "All",
     "showLiked": "Only liked",
     "showDisliked": "Only disliked"
+  },
+
+  "LandingPage": {
+    "mainTitle": "Lithuanian Press Photography",
+    "contestsTitle": "Contests"
+  },
+
+  "CompetitionPreview": {
+    "recordsTitle": "Competition records",
+    "loadingTitle": "Loading...",
+    "userTitle": "User:",
+    "categoryTitle": "Category:"
   }
 }

--- a/javinukai-front/public/locales/lt/translation.json
+++ b/javinukai-front/public/locales/lt/translation.json
@@ -15,7 +15,7 @@
   },
 
   "layout": {
-    "name": "Lietuvos spaudos fotografija",
+    "name": "Lietuvos Spaudos Fotografija",
     "login": "Prisijungimas",
     "loggedOutSuccess": "Sėkmingai atsijungėte!",
     "adminContact": "Administracija"
@@ -273,7 +273,8 @@
     "participationSuccess": "Dalyvavimo prašymas išsiųstas",
     "participationError": "Įvyko klaida siunčiant dalyvavimo prašymą",
     "userEntries": "Jūsų pateikimai",
-    "entries": "Visi pateikimai"
+    "entries": "Visi pateikimai",
+    "contestEditTitle": "Redaguoti konkursą"
   },
 
   "CategoryItem": {
@@ -399,6 +400,7 @@
     "categoryDescription": "Aprašymas",
     "categoryTotalSubmissions": "Maksimalus pateikimų skaičius",
     "categoryType": "Kategorijos tipas",
+    "categorySelectType": "Pasirinkite kategorijos tipą",
     "categoryCreateButton": "Sukurti kategoriją",
     "categoryCreateSuccess": "Kategorija sukurta sėkmingai",
     "categoryCreateError": "Kuriant kategoriją įvyko klaida",
@@ -517,6 +519,18 @@
     "showAll": "Visas",
     "showLiked": "Tik patikusias",
     "showDisliked": "Tik nepatikusias"
-  }
+  },
+
+  "LandingPage": {
+    "mainTitle": "Lietuvos Spaudos Fotografija",
+    "contestsTitle": "Konkursai"
+  },
+
+  "CompetitionPreview": {
+    "recordsTitle": "Konkursų įrašai",
+    "loadingTitle": "Kraunama...",
+    "userTitle": "Vartotojas:",
+    "categoryTitle": "Kategorija:"
+    }
 }
 

--- a/javinukai-front/src/Components/Contest-Components/CompetitionPreview.jsx
+++ b/javinukai-front/src/Components/Contest-Components/CompetitionPreview.jsx
@@ -1,9 +1,11 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import axios from "axios";
+import { useTranslation } from "react-i18next";
 
 function CompetitionRecordPreview() {
   const [competitionRecords, setCompetitionRecords] = useState([]);
   const [loading, setLoading] = useState(true);
+  const { t } = useTranslation();
 
   useEffect(() => {
     const fetchCompetitionRecords = async () => {
@@ -24,16 +26,16 @@ function CompetitionRecordPreview() {
 
   return (
     <div>
-      <h2>Competition Records</h2>
+      <h2>{t("ContestPreview.recordsTitle")}</h2>
       {loading ? (
-        <p>Loading...</p>
+        <p>{t("ContestPreview.loadingTitle")}</p>
       ) : (
         <ul>
           {competitionRecords.map((record) => (
             <li key={record.id}>
               <h3>{record.contestName}</h3>
-              <p>User: {record.userName}</p>
-              <p>Category: {record.categoryName}</p>
+              <p>{t("ContestPreview.userTitle")} {record.userName}</p>
+              <p>{t("ContestPreview.categoryTitle")} {record.categoryName}</p>
               {/* Add more details as needed */}
             </li>
           ))}

--- a/javinukai-front/src/Components/Contest-Components/CreateContest.jsx
+++ b/javinukai-front/src/Components/Contest-Components/CreateContest.jsx
@@ -12,6 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 export default function CreateContest({
   initialContestInfo,
   initialCategories,
+  title
 }) {
   const queryClient = useQueryClient();
   const {
@@ -108,7 +109,7 @@ export default function CreateContest({
     }
     setThumbnailFile(e.target.files[0]);
   }
-
+  
   return (
     <div
       className={`${
@@ -116,7 +117,7 @@ export default function CreateContest({
       } mx-auto p-6 bg-white rounded-md shadow-md`}
     >
       <h2 className="text-2xl font-semibold mb-4">
-        {t("CreateContest.contestTitle")}
+      {title ? title : t("CreateContest.contestTitle")}
       </h2>
       <form id="contest-create-form" onSubmit={handleSubmit(onSubmit)}>
         <div className="mb-4">

--- a/javinukai-front/src/pages/ContestDetailsPage.jsx
+++ b/javinukai-front/src/pages/ContestDetailsPage.jsx
@@ -16,14 +16,16 @@ import Modal from "../Components/Modal";
 import CreateContest from "../Components/Contest-Components/CreateContest";
 
 function EditContestSection({ contestInfo, categoriesInfo }) {
+  const { t } = useTranslation();
   const [modalOpen, setModalOpen] = useState(false);
   return (
     <div>
       <Button onClick={() => setModalOpen(true)}>Edit Contest</Button>
       <Modal isOpen={modalOpen} setIsOpen={setModalOpen}>
         <CreateContest
-          initialContestInfo={contestInfo?.contest}
-          initialCategories={categoriesInfo}
+        title={t("ContestDetailsPage.contestEditTitle")}
+        initialContestInfo={contestInfo?.contest}
+        initialCategories={categoriesInfo}
         />
       </Modal>
     </div>

--- a/javinukai-front/src/pages/LandingPage.jsx
+++ b/javinukai-front/src/pages/LandingPage.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import getLatestContestThumbnails from "../services/contests/getLatestContestThumbnails";
 import { useEffect, useState } from "react";
 import logo from "../assets/logo.jpg";
+import { useTranslation } from "react-i18next";
 
 function ImageContainer({ imageUrl }) {
   return (
@@ -27,6 +28,7 @@ function LandingPage() {
     queryFn: getLatestContestThumbnails,
   });
   const [images, setImages] = useState([]);
+  const { t } = useTranslation();
 
   useEffect(
     function () {
@@ -57,13 +59,13 @@ function LandingPage() {
       </div>
       <div className="flex flex-col space-y-12">
         <h1 className="xl:text-5xl text-2xl w-8 xl:w-12 leading-normal font-bold text-white">
-          Lithuanian Press Photography
+          {t("LandingPage.mainTitle")}
         </h1>
         <Link
           className="text-3xl text-white hover:translate-x-5 transition"
           to="/contests"
         >
-          Contests {"➡️"}
+          {t("LandingPage.contestsTitle")} {"➡️"}
         </Link>
       </div>
     </div>


### PR DESCRIPTION
- Fixed an issue (When admin presses on edit contest button, the title would've displayed 'Create contest')
- Added missing translations for LandingPage, CompetitionPreview.
- Fixed incorrect translations for Lithuanian language.